### PR TITLE
Adjust *.sock paths for snap configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Description = Push daemon for Nextcloud clients
 
 [Service]
 Environment=PORT=7867 # Change if you already have something running on this port
-Environment=DATABASE_URL=mysql://nextcloud:CHANGEME@localhost/nextcloud?socket=/tmp/snap.nextcloud/tmp/sockets/mysql.sock
-Environment=REDIS_URL=redis+unix:///tmp/snap.nextcloud/tmp/sockets/redis.sock
+Environment=DATABASE_URL=mysql://nextcloud:CHANGEME@localhost/nextcloud?socket=/tmp/snap-private-tmp/snap.nextcloud/tmp/sockets/mysql.sock
+Environment=REDIS_URL=redis+unix:///tmp/snap-private-tmp/snap.nextcloud/tmp/sockets/redis.sock
 ExecStart=/var/snap/nextcloud/current/nextcloud/extra-apps/notify_push/bin/x86_64/notify_push /var/snap/nextcloud/current/nextcloud/config/config.php
 User=root
 


### PR DESCRIPTION
Signed-off-by: Pilzinsel64 <pilzinsel64@gmx.de>

The snap environment seems to got an update. The path to the private tmp paths for snaps has been changed over night.
Without this change it is not possible for new users to setup their snap.

See changes for detailed. Should be self-explaining. ;)